### PR TITLE
Openai embedding

### DIFF
--- a/.github/workflows/qa-normal.yml
+++ b/.github/workflows/qa-normal.yml
@@ -89,6 +89,9 @@ jobs:
           AWS_REGION: us-east-1
           POSTHOG_KEY: secret
           SENTRY_DSN: secret
+          OPENAI_DEPLOYMENT: ${{ secrets.OPENAI_DEPLOYMENT }}
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          OPENAI_KEY_OVERRIDE: ${{ secrets.OPENAI_KEY_OVERRIDE }}
 
       - name: 'Report Coverage'
         uses: davelosert/vitest-coverage-report-action@v2

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To work, the container require a few environment variables:
 
 mandatory:
 
-- `API_KEY`: this will be used to communicate with Memoire, the API_KEY needs to be present in the requests headers:
+- `API_KEY`: this will be used to communicate with Memoire. Make it secure (ex: use `openssl rand -hex 32`). The API_KEY needs to be present in the requests headers:
 
 ```bash
 curl http://localhost:3003/endpoint -H "Authorization: Bearer my_API_KEY"
@@ -48,6 +48,8 @@ optional:
 - `AWS_SECRET_ACCESS_KEY`: if you are using a cohere or titan model from bedrock
 - `AWS_ACCESS_KEY_ID`: if you are using a cohere or titan model from bedrock
 - `AWS_REGION`: if you are using a cohere or titan model from bedrock
+- `OPENAI_KEY`: if you are using OpenAI models (Azure or not)
+- `OPENAI_DEPLOYMENT`: if you are using Azure open AI models (leave empty to use OpenAI's servers)
 
 ### API documentation
 

--- a/src/ai/embedding/model/ai-embedding-model-openai.ts
+++ b/src/ai/embedding/model/ai-embedding-model-openai.ts
@@ -1,13 +1,72 @@
 // libs
+import { type Static, Type } from '@sinclair/typebox';
+import { Check } from '@sinclair/typebox/value';
+import axios from 'axios';
 // eslint-disable-next-line camelcase
 import { get_encoding } from 'tiktoken';
 
 // embedding models contracts
 import type {
+  EmbeddingModelInput,
   // EmbeddingModelInput,
   EmbeddingModelOutput,
   IsTooLargeInput,
 } from './ai-embedding-model-contracts.js';
+import {
+  errorReport,
+  logger,
+  Sentry,
+} from '../../../database/reporting/database-interface-reporting.ee.js';
+
+/* v8 ignore start */
+if (!process.env.OPENAI_KEY) {
+  throw new Error('Please set OPENAI_KEY');
+}
+if (!process.env.OPENAI_DEPLOYMENT) {
+  logger.info('Using OpenAI for embedding');
+}
+if (process.env.OPENAI_DEPLOYMENT) {
+  logger.info('Using Azure Open AI for embedding');
+}
+/* v8 ignore stop */
+
+/**
+ * https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#responses-1
+ */
+export const azOpenAIEmbedResponseSchema = Type.Object(
+  {
+    data: Type.Array(
+      Type.Object(
+        {
+          embedding: Type.Array(Type.Number()),
+          index: Type.Number(),
+          object: Type.Literal('embedding'),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+    model: Type.String(),
+    object: Type.String(),
+    usage: Type.Object(
+      {
+        // eslint-disable-next-line camelcase
+        prompt_tokens: Type.Number(),
+        // eslint-disable-next-line camelcase
+        total_tokens: Type.Number(),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+export type AzOpenAIEmbedResponse = Static<typeof azOpenAIEmbedResponseSchema>;
+
+export interface AzOpenAIEmbedBody {
+  dimensions: number;
+  input: string | string[];
+  model: 'text-embedding-3-large' | 'text-embedding-3-small';
+  user?: string;
+}
 
 /**
  * Verify that the string sent has less tokens than the maximum possible for the model
@@ -25,8 +84,60 @@ export function isTooLarge({ text }: IsTooLargeInput): boolean {
 /**
  * Call the embedding model
  * https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#responses-1
+ * https://platform.openai.com/docs/api-reference/embeddings/create
+ * @param root named parameters
+ * @param root.chunks the chunk to embed
  * @returns an object with the averaged embedding an an array of chunk embeddings
  */
-export async function embedDocument(): Promise<EmbeddingModelOutput> {
-  throw new Error('OpenAI is not implemented');
+export async function embedDocument({
+  chunks,
+}: EmbeddingModelInput): Promise<EmbeddingModelOutput> {
+  try {
+    if (
+      chunks.some((chunk) => {
+        return isTooLarge({ text: chunk });
+      })
+    ) {
+      throw new Error('A document was too large');
+    }
+    const { data } = await axios<AzOpenAIEmbedResponse>({
+      data: {
+        dimensions: 256,
+        input: chunks,
+        model: 'text-embedding-3-large',
+      } satisfies AzOpenAIEmbedBody,
+      headers: process.env.OPENAI_DEPLOYMENT
+        ? {
+            'api-key': process.env.OPENAI_KEY,
+            'Content-Type': 'application/json',
+          }
+        : {
+            Authorization: `Bearer ${process.env.OPENAI_KEY}`,
+            'Content-Type': 'application/json',
+          },
+      method: 'POST',
+      url:
+        process.env.OPENAI_DEPLOYMENT ?? 'https://api.openai.com/v1/embeddings',
+    });
+    if (data.data.length === 0) {
+      throw new Error('OpenAI embedding output had no embeddings');
+    }
+    if (!Check(azOpenAIEmbedResponseSchema, data)) {
+      Sentry.captureMessage('Discrepancy: in OpenAI embedding model');
+    }
+    return data.data.map((embedding) => {
+      return {
+        chunkID: embedding.index,
+        chunkText: chunks[embedding.index],
+        embedding: embedding.embedding,
+      };
+    });
+  } catch (error) {
+    const message = 'The embedding function had an error';
+    await errorReport({
+      error,
+      message,
+    });
+    throw error;
+  }
 }

--- a/src/ai/embedding/model/tests/integration/ai-embedding-model-openai-integration.test.ts
+++ b/src/ai/embedding/model/tests/integration/ai-embedding-model-openai-integration.test.ts
@@ -1,0 +1,80 @@
+// libs
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// test function
+import { embedDocument } from '../../ai-embedding-model-openai.js';
+
+beforeEach(() => {
+  vi.unstubAllEnvs(); /* cSpell: disable-line */
+});
+
+// spy
+vi.mock('axios', async () => {
+  // from https://github.com/vitest-dev/vitest/issues/855
+  const actual = await import('axios');
+  const mocked = {};
+  for (const key of Object.keys(actual)) {
+    // @ts-expect-error don't care
+    // eslint-disable-next-line unicorn/prefer-ternary
+    if (typeof actual[key] === 'function') {
+      // @ts-expect-error don't care
+      mocked[key] = vi.fn(actual[key]);
+    } else {
+      // @ts-expect-error don't care
+      mocked[key] = actual[key];
+    }
+  }
+  return mocked;
+});
+import module from 'axios';
+const axiosSpy = vi.mocked(module);
+
+describe('embedDocument with Azure', async () => {
+  test('embedDocument will embed a document ', async () => {
+    const response = await embedDocument({
+      chunks: ['test document'],
+    });
+    expect(response).toBeDefined();
+    expect(response.length).toBe(1);
+    expect(axiosSpy).toHaveBeenCalledOnce();
+    // @ts-expect-error don't care
+    expect(axiosSpy.mock.calls[0][0].url).toContain('openai.azure.com');
+  });
+
+  test('multiple chunks will give multiple embeddings', async () => {
+    const response = await embedDocument({
+      chunks: ['text 1', 'text 2'],
+    });
+    expect(response.length).toBe(2);
+    expect(axiosSpy).toHaveBeenCalledOnce();
+    // @ts-expect-error don't care
+    expect(axiosSpy.mock.calls[0][0].url).toContain('openai.azure.com');
+  });
+});
+
+describe('embedDocument with OpenAI', async () => {
+  test('embedDocument will embed a document ', async () => {
+    vi.stubEnv('OPENAI_KEY', process.env.OPENAI_KEY_OVERRIDE);
+    vi.stubEnv('OPENAI_DEPLOYMENT', undefined);
+    const response = await embedDocument({
+      chunks: ['test document'],
+    });
+    expect(response).toBeDefined();
+    expect(response.length).toBe(1);
+    expect(axiosSpy).toHaveBeenCalledOnce();
+    // @ts-expect-error don't care
+    expect(axiosSpy.mock.calls[0][0].url).toContain('api.openai.com');
+  });
+
+  test('multiple chunks will give multiple embeddings', async () => {
+    vi.stubEnv('OPENAI_KEY', process.env.OPENAI_KEY_OVERRIDE);
+    vi.stubEnv('OPENAI_DEPLOYMENT', undefined);
+    const response = await embedDocument({
+      chunks: ['text 1', 'text 2'],
+    });
+    expect(response.length).toBe(2);
+    expect(axiosSpy).toHaveBeenCalledOnce();
+    // @ts-expect-error don't care
+    expect(axiosSpy.mock.calls[0][0].url).toContain('api.openai.com');
+  });
+});

--- a/src/api/api-config.ts
+++ b/src/api/api-config.ts
@@ -8,8 +8,8 @@ import fastifySwaggerUi from '@fastify/swagger-ui';
 import { setupServer } from '../server/server-init.js';
 
 // api
-import { searchRouter } from './search/api-search-routes.js';
 import { logger } from '../database/reporting/database-external-config.js';
+import { searchRouter } from './search/api-search-routes.js';
 
 // server
 export const app = await setupServer();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 /* v8 ignore start */
 import { defineConfig } from 'vitest/config';
+import { loadEnv } from 'vite';
 
 export default defineConfig({
   test: {
@@ -19,8 +20,6 @@ export default defineConfig({
       reporter: ['text', 'json-summary', 'json'], // cSpell: disable-line
     },
     clearMocks: true,
-    env: {
-      NODE_ENV: 'test',
-    },
+    env: loadEnv('', process.cwd(), ''),
   },
 });


### PR DESCRIPTION
This PR close #32 

@sriram-vinnakota, you will need to deploy a new model in the azure region, otherwise my tests (using a specific key and deployment) will clash with your secrets.

When you have finished the review of this PR, let me know what I need to deploy, so the secrets can be reused


## Changes

- Add open AI Azure embeddings
- Add an override for regular openAI requests (the payload is slightly different: URL and authorisation in the headers is different