### PR TITLE
adding weightage RRF, and filtered low scores from search results 

### DIFF
--- a/src/ai/ai-reranker.ts
+++ b/src/ai/ai-reranker.ts
@@ -10,18 +10,21 @@ type ReRankOutput = {
 /**
  * Calculate the RRF score
  * @param root named params
- * @param root.searchRank  number represents rank of the search result
+ * @param root.searchRank  number represents rank of the search result1 search metod to reduce emphasis on the position.
+ * @param root.serchWeightage weight you wanna give to search method, you may aslo use search score as a weight
  * @param root.smoothingConstant smoothing constant for re-ranking, usually 60
  * @returns a number representing rrf score
  */
 async function calculateRRF({
   searchRank,
+  serchWeightage = 1,
   smoothingConstant = 60,
 }: {
   searchRank: number;
+  serchWeightage?: number;
   smoothingConstant?: number;
 }): Promise<number> {
-  return 1 / (smoothingConstant + (searchRank + 1));
+  return serchWeightage / (smoothingConstant + (searchRank + 1));
 }
 
 /**
@@ -50,19 +53,46 @@ export async function rerank({
   if (keywordResults.length === 0) {
     return vectorResults;
   }
+  //filtering low score value, 0.3 is suggested for vector search without HyDE logic
+  const filterdVectoResults = vectorResults.filter((vectorResult) => {
+    return vectorResult.score >= 0.3;
+  });
+  const vectorRRFPromise = filterdVectoResults.map(async (result, position) => {
+    return {
+      ...result,
+      score: await calculateRRF({ searchRank: position, serchWeightage: 0.6 }),
+    };
+  });
+  const keywordScores = keywordResults.map((keywordResult) => {
+    return keywordResult.score;
+  });
 
-  const vectorRRFPromise = vectorResults.map(async (result, position) => {
-    return {
-      ...result,
-      score: await calculateRRF({ searchRank: position }),
-    };
-  });
-  const keywordRRFPromise = keywordResults.map(async (result, position) => {
-    return {
-      ...result,
-      score: await calculateRRF({ searchRank: position }),
-    };
-  });
+  //Normalizing the keywordscore and filtering scores below 0.3
+  const keywordMinScore = Math.min(...keywordScores);
+  const keywordMaxScore = Math.max(...keywordScores);
+  const normalizedkeywordResults = keywordResults
+    .map((keywordResult) => {
+      return {
+        ...keywordResult,
+        score:
+          (keywordResult.score - keywordMinScore) /
+          (keywordMaxScore - keywordMinScore),
+      };
+    })
+    .filter((result) => {
+      return result.score >= 0.3;
+    });
+  const keywordRRFPromise = normalizedkeywordResults.map(
+    async (result, position) => {
+      return {
+        ...result,
+        score: await calculateRRF({
+          searchRank: position,
+          serchWeightage: 0.4,
+        }),
+      };
+    },
+  );
   const vectorRRF = await Promise.all(vectorRRFPromise);
   const keywordRRF = await Promise.all(keywordRRFPromise);
 

--- a/src/ai/embedding/ai-embeddings-interface.ts
+++ b/src/ai/embedding/ai-embeddings-interface.ts
@@ -32,6 +32,7 @@ export async function autoEmbedQuery({
 }: {
   query: string;
 }): Promise<number[]> {
+  // todo: implemet to improve vector retrival. ref: https://medium.com/prompt-engineering/hyde-revolutionising-search-with-hypothetical-document-embeddings-3474df795af8
   const embeddings = await embedQuery({ chunks: [query] });
   return embeddings[0].embedding;
 }


### PR DESCRIPTION
# This branch is referring to issue #60:
## What's done
- **Normalize scores of BM25** and filtered out low scores.
- **Added weight to RRF** to give  less importance to FTS.
## Reasons:
- Normalized because BM25 scores does not bound to range(0,1)
- **Less weight to BM25** search because, to overcome case where **BM25 retrieves all low score**, in this case filtering low scores after normalizing will not be enough, and before normalizing is not possible.
## Pros:
- will handle FTS better than before
## Cons:
- still does not handle the case when FTS retrieves all low score docs
## What's need to be done:
- To overcome BM25 issue, we need to apply reranker model on top of FTS scores, suggested mxbai-rerank-xsmall-v1 for local model and good perforce, and NV-RerankQA-Mistral-4B-v3 for non local model with excellent performance. [reference](https://arxiv.org/html/2409.07691v1)
- Implement Hyde, RAGFusion and crossEncoder bbased reranker:
  - **Reranker model**:  To overcome the issue and improve RRF as mentioned above, **FOR THIS I NEED TO ACCESS DOCS AFTER RETRIEVAL**  
  - **RagFusion** will improve both BM25 and vector search (just need to generate different queries and do retrieval for all of em).
  - **HYDE:** to improve vector search, need to generate a doc based on query, and do retrieval on this hypocritical doc.
  - HYDE is very effective, for this its advised not to go with agentic chunking, better to go with semantic chunking or normal chunking.
  
close #60 
 