### PR TITLE
Adding hyde

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,3 +7,5 @@ EMBEDDING_MODEL= # cohere | openai | titanG1 | titanV2 (optional) choose between
 AWS_SECRET_ACCESS_KEY= # (optional) needed if you want to use cohere or titan from AWS bedrock
 AWS_ACCESS_KEY_ID= # (optional) needed if you want to use cohere or titan from AWS bedrock
 AWS_REGION= # (optional) needed if you want to use cohere or titan from AWS bedrock
+AZURE_OPENAI_KEY= # (optional) needed if you are using hyde/enhancedSemantic parameter
+AZURE_OPENAI_URL= # (optional) needed if you are using hyde/enhancedSemantic parameter, the URL for from your LLM deployment

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Memoire is a text search/RAG solution. It handles for you all the details of mak
 ## Features
 
 - **Deploy in one day**: We made our API as intuitive as possible, so you can get a working RAG in a few minutes instead of months.
-- **State of the art retrieval**: Benefit from the latest and best algorithms of retrieval such as hybrid search, agentic chunking and many more.
+- **State of the art retrieval**: Benefit from the latest and best algorithms of retrieval such as hybrid search, agentic chunking, HyDE and many more.
 - **Auto document parsing**: Forget about parsing html, xml, docx, pdfs and the gazillion document types out there. Memoire already does it for you.
 
 ### License & running the app

--- a/docs/tutorials/python/index.ipynb
+++ b/docs/tutorials/python/index.ipynb
@@ -19,12 +19,13 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
+    "## **1. Import required libraries**\n",
     "First, we'll set the app url and the API key in memory, and import an HTTP request library."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1520c648-c400-4010-80ce-3cefcbb43a90",
    "metadata": {},
    "outputs": [],
@@ -32,7 +33,7 @@
     "import requests\n",
     "import json\n",
     "\n",
-    "API_KEY = \"123\" # secure me\n",
+    "API_KEY = \"abc123\" # secure me\n",
     "MEMOIRE_URL = 'http://localhost:3003'"
    ]
   },
@@ -43,6 +44,7 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
+    "## **2. Define helper functions**\n",
     "Next, we define some helper functions for convenience"
    ]
   },
@@ -62,11 +64,12 @@
     "        }\n",
     "    )\n",
     "\n",
-    "def search(query):\n",
+    "def search(query, enhance_similarity=False):\n",
     "    return requests.post(\n",
     "        MEMOIRE_URL + \"/search\",\n",
     "        headers = {\"Authorization\": f\"Bearer {API_KEY}\"},\n",
     "        json = {\n",
+    "            \"enhanceSimilarity\": enhance_similarity,\n",
     "            \"maxResults\": 3,\n",
     "            \"query\": query\n",
     "        }\n",
@@ -78,6 +81,7 @@
    "id": "502404f0-2e39-4c43-9f95-3ceaef27e301",
    "metadata": {},
    "source": [
+    "## **3. Ingest Documents**\n",
     "Now this is time to ingest some documents.\n",
     "\n",
     "In this example, we index cooking recipes from a few websites and MS Word documents."
@@ -125,12 +129,23 @@
    "id": "694fd904-a60e-4859-85fd-29bc29dec478",
    "metadata": {},
    "source": [
-    "Finally, we can do our retrieval."
+    "## **4. Search retrieval**\n",
+    "Finally, we can do our retrieval.\n",
+    "In this example we are going to do two search, a standard and an enhanced "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0c21e21",
+   "metadata": {},
+   "source": [
+    "### *4.1 standard search*\n",
+    "Will give best results by giving importance to both words and semantics"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "3d663a20-e6e7-40c9-b6c5-adab5ec48894",
    "metadata": {},
    "outputs": [
@@ -174,7 +189,28 @@
     }
    ],
    "source": [
-    "search_response = search(\"carrots\")\n",
+    "search_response = search(\"suggest me some simple recipes with carrots\")\n",
+    "\n",
+    "print(json.dumps(search_response.json(), indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d3996c2",
+   "metadata": {},
+   "source": [
+    "### *4.2. standard search*\n",
+    "Same as standard search, but it will enhance the semantic search, not best for analytics or domain specific questions\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a851f83c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search_response = search(\"suggest me some simple recipes with carrots\", True)\n",
     "\n",
     "print(json.dumps(search_response.json(), indent=2))"
    ]
@@ -200,7 +236,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "type": "module",
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.706.0",
+    "@azure/openai": "1.0.0-beta.12",
     "@fastify/compress": "^8.0.1",
     "@fastify/cors": "^10.0.1",
     "@fastify/helmet": "^13.0.0",

--- a/src/ai/ai-reranker.ts
+++ b/src/ai/ai-reranker.ts
@@ -54,23 +54,25 @@ export async function rerank({
     return vectorResults;
   }
   //filtering low score value, 0.3 is suggested for vector search without HyDE logic
-  const filterdVectoResults = vectorResults.filter((vectorResult) => {
+  const filteredVectorResults = vectorResults.filter((vectorResult) => {
     return vectorResult.score >= 0.3;
   });
-  const vectorRRFPromise = filterdVectoResults.map(async (result, position) => {
-    return {
-      ...result,
-      score: await calculateRRF({ searchRank: position, searchWeight: 0.6 }),
-    };
-  });
+  const vectorRRFPromise = filteredVectorResults.map(
+    async (result, position) => {
+      return {
+        ...result,
+        score: await calculateRRF({ searchRank: position, searchWeight: 0.6 }),
+      };
+    },
+  );
   const keywordScores = keywordResults.map((keywordResult) => {
     return keywordResult.score;
   });
 
-  //Normalizing the keywordscore and filtering scores below 0.3
+  //Normalizing the keywordScore and filtering scores below 0.3
   const keywordMinScore = Math.min(...keywordScores);
   const keywordMaxScore = Math.max(...keywordScores);
-  const normalizedkeywordResults = keywordResults
+  const normalizedKeywordResults = keywordResults
     .map((keywordResult) => {
       return {
         ...keywordResult,
@@ -82,7 +84,7 @@ export async function rerank({
     .filter((result) => {
       return result.score >= 0.3;
     });
-  const keywordRRFPromise = normalizedkeywordResults.map(
+  const keywordRRFPromise = normalizedKeywordResults.map(
     async (result, position) => {
       return {
         ...result,

--- a/src/ai/embedding/ai-embeddings-interface.ts
+++ b/src/ai/embedding/ai-embeddings-interface.ts
@@ -2,6 +2,23 @@
 import type { EmbeddingModelOutput } from './model/ai-embedding-model-contracts.js';
 import { createLengthBasedChunks } from './chunking/ai-chunking-fixed-size.js';
 import { embedDocument, embedQuery } from './model/index.js';
+import {
+  AzureKeyCredential,
+  type ChatRequestMessageUnion,
+  OpenAIClient,
+} from '@azure/openai';
+
+if (process.env.AZURE_OPENAI_URL === undefined) {
+  throw new Error('please set the env variable OPENAI_URL');
+}
+if (process.env.AZURE_OPENAI_KEY === undefined) {
+  throw new Error('please set the env variable OPENAI_KEY');
+}
+
+const openAIClient = new OpenAIClient(
+  process.env.AZURE_OPENAI_URL,
+  new AzureKeyCredential(process.env.AZURE_OPENAI_KEY),
+);
 
 export { isTooLarge } from './model/index.js';
 
@@ -25,14 +42,48 @@ export async function autoEmbed({
  * Embed a search query
  * @param root named parameters
  * @param root.query the query to embed
+ * @param root.useHyde creates an hypothetical answer and embed it instead of embedding query
  * @returns the embedding of the query
  */
 export async function autoEmbedQuery({
   query,
+  useHyde = true,
 }: {
   query: string;
+  useHyde: boolean;
 }): Promise<number[]> {
-  // todo: implemet HYDE to improve vector retrival. ref: https://medium.com/prompt-engineering/hyde-revolutionising-search-with-hypothetical-document-embeddings-3474df795af8
+  if (useHyde) {
+    const generateAnswerPrompt: ChatRequestMessageUnion[] = [
+      {
+        content:
+          'You are an answering bot who will just generate answer to the given question',
+        role: 'system',
+      },
+      {
+        content: `Please write a passage to answer the question \nQuestion: ${query}`,
+        role: 'user',
+      },
+    ];
+
+    const response = await openAIClient.getChatCompletions(
+      'gpt-4o',
+      generateAnswerPrompt,
+    );
+    const hypotheticalAnswer = response.choices[0].message?.content;
+    if (hypotheticalAnswer === null || hypotheticalAnswer === undefined) {
+      throw new Error(
+        'Azure openAI model could not generate hypothetical answer for query',
+      );
+    }
+    const answerChunk = createLengthBasedChunks({
+      document: hypotheticalAnswer,
+    })[0];
+
+    const HypotheticalDocumentEmbedding = await embedDocument({
+      chunks: [answerChunk],
+    }); // Good to embed in the same way we embed doc, to get most out of vector similarity
+    return HypotheticalDocumentEmbedding[0].embedding;
+  }
   const embeddings = await embedQuery({ chunks: [query] });
   return embeddings[0].embedding;
 }

--- a/src/ai/embedding/ai-embeddings-interface.ts
+++ b/src/ai/embedding/ai-embeddings-interface.ts
@@ -9,11 +9,19 @@ import {
 } from '@azure/openai';
 
 if (process.env.AZURE_OPENAI_URL === undefined) {
-  throw new Error('please set the env variable OPENAI_URL');
+  throw new Error('please set the env variable AZURE_OPENAI_URL');
 }
 if (process.env.AZURE_OPENAI_KEY === undefined) {
-  throw new Error('please set the env variable OPENAI_KEY');
+  throw new Error('please set the env variable AZURE_OPENAI_KEY');
 }
+
+const modelNameRegex = process.env.AZURE_OPENAI_URL.match(
+  /deployments\/([^\/]+)/,
+); // https://regex101.com/r/M3flvm/1
+if (modelNameRegex == null) {
+  throw new Error('Please set the valid env variable for AZURE_OPENAI_URL');
+}
+const modelName = modelNameRegex[0];
 
 const openAIClient = new OpenAIClient(
   process.env.AZURE_OPENAI_URL,
@@ -66,7 +74,7 @@ export async function autoEmbedQuery({
     ];
 
     const response = await openAIClient.getChatCompletions(
-      'gpt-4o',
+      modelName,
       generateAnswerPrompt,
     );
     const hypotheticalAnswer = response.choices[0].message?.content;

--- a/src/ai/embedding/ai-embeddings-interface.ts
+++ b/src/ai/embedding/ai-embeddings-interface.ts
@@ -50,7 +50,7 @@ export async function autoEmbedQuery({
   useHyde = true,
 }: {
   query: string;
-  useHyde: boolean;
+  useHyde?: boolean;
 }): Promise<number[]> {
   if (useHyde) {
     const generateAnswerPrompt: ChatRequestMessageUnion[] = [

--- a/src/api/search/api-search-routes.ts
+++ b/src/api/search/api-search-routes.ts
@@ -156,9 +156,9 @@ Note:
       },
     },
     async (request, _reply): Promise<SearchResponse> => {
-      const { maxResults, query } = request.body;
+      const { enhanceSimilarity, maxResults, query } = request.body;
       return {
-        results: await search({ maxResults, query }),
+        results: await search({ enhanceSimilarity, maxResults, query }),
       };
     },
   );

--- a/src/api/search/api-search-schemas.ts
+++ b/src/api/search/api-search-schemas.ts
@@ -66,6 +66,12 @@ export type DocumentLinkBody = Static<typeof documentLinkBodySchema>;
 
 export const searchBodySchema = Type.Object(
   {
+    enhanceSimilarity: Type.Optional(
+      Type.Boolean({
+        default: false,
+        description: 'Enhance the semantic search',
+      }),
+    ),
     maxResults: Type.Optional(
       Type.Number({
         default: 100,

--- a/src/core/core-search.ts
+++ b/src/core/core-search.ts
@@ -59,14 +59,17 @@ export async function addDocuments({
 /**
  * Search for the most similar documents, and return an array of scored documents
  * @param root named parameters
+ * @param root.enhanceSimilarity increase the semantic search if set true (default: false)
  * @param root.maxResults the maximum number of results returned by the query (default: 100)
  * @param root.query the query for keyword search
  * @returns an object with two arrays: one for vector search, one for keyword search
  */
 export async function search({
+  enhanceSimilarity = false,
   maxResults = 100,
   query,
 }: {
+  enhanceSimilarity?: boolean;
   maxResults?: number;
   query: string;
 }): Promise<
@@ -79,7 +82,10 @@ export async function search({
     title: string | undefined;
   }[]
 > {
-  const embeddingPromise = autoEmbedQuery({ query });
+  const embeddingPromise = autoEmbedQuery({
+    query,
+    useHyde: enhanceSimilarity,
+  });
   const keywordPromise = FTSSearch({ maxResults, query });
   const vectorPromise = vectorSearch({
     embedding: await embeddingPromise,

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,7 @@ __metadata:
   dependencies:
     "@ansearch/config": "npm:^0.0.3"
     "@aws-sdk/client-bedrock-runtime": "npm:^3.706.0"
+    "@azure/openai": "npm:1.0.0-beta.12"
     "@fastify/compress": "npm:^8.0.1"
     "@fastify/cors": "npm:^10.0.1"
     "@fastify/helmet": "npm:^13.0.0"
@@ -618,6 +619,108 @@ __metadata:
     aws-crt:
       optional: true
   checksum: 10c0/9dd7ef236ff13552f559d0e78bfffe424032dc4040306808542a2eedbe80801ae05389c415b770461b6b39a0b35cdbebf97e673e6f7132e05121708acee3db83
+  languageName: node
+  linkType: hard
+
+"@azure-rest/core-client@npm:^1.1.7":
+  version: 1.4.0
+  resolution: "@azure-rest/core-client@npm:1.4.0"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    "@azure/core-auth": "npm:^1.3.0"
+    "@azure/core-rest-pipeline": "npm:^1.5.0"
+    "@azure/core-tracing": "npm:^1.0.1"
+    "@azure/core-util": "npm:^1.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/be389a5ba39f97d09f9a927c07caac2a6dc8e607bcdcf1b81f25c43ea78192b3d6414af79962531948c14314edc1363aead27fbe96a8a93b41cfc9b297c2e2e9
+  languageName: node
+  linkType: hard
+
+"@azure/abort-controller@npm:^2.0.0":
+  version: 2.1.2
+  resolution: "@azure/abort-controller@npm:2.1.2"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3771b6820e33ebb56e79c7c68e2288296b8c2529556fbd29cf4cf2fbff7776e7ce1120072972d8df9f1bf50e2c3224d71a7565362b589595563f710b8c3d7b79
+  languageName: node
+  linkType: hard
+
+"@azure/core-auth@npm:^1.3.0, @azure/core-auth@npm:^1.4.0, @azure/core-auth@npm:^1.8.0":
+  version: 1.9.0
+  resolution: "@azure/core-auth@npm:1.9.0"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    "@azure/core-util": "npm:^1.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b7d8f33b81a8c9a76531acacc7af63d888429f0d763bb1ab8e28e91ddbf1626fc19cf8ca74f79c39b0a3e5acb315bdc4c4276fb979816f315712ea1bd611273d
+  languageName: node
+  linkType: hard
+
+"@azure/core-rest-pipeline@npm:^1.13.0, @azure/core-rest-pipeline@npm:^1.5.0":
+  version: 1.18.1
+  resolution: "@azure/core-rest-pipeline@npm:1.18.1"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    "@azure/core-auth": "npm:^1.8.0"
+    "@azure/core-tracing": "npm:^1.0.1"
+    "@azure/core-util": "npm:^1.11.0"
+    "@azure/logger": "npm:^1.0.0"
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e63d110f799a74ed20925e59ee70eced355f76130a2283393ce109b49365c97a436e8ddde29badee138c17cf0ecf33c26b9ce3cfbf64cf98b904ab50e6bdedff
+  languageName: node
+  linkType: hard
+
+"@azure/core-sse@npm:^2.0.0":
+  version: 2.1.3
+  resolution: "@azure/core-sse@npm:2.1.3"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/364df0e6ffe5069951eaf8f9f21ab8606b8e861fa96a66ae4a623015947ca4208e018c11a271b64931ad3955d912bfd72ad9ebd5908eac835eac5ded035b370a
+  languageName: node
+  linkType: hard
+
+"@azure/core-tracing@npm:^1.0.1":
+  version: 1.2.0
+  resolution: "@azure/core-tracing@npm:1.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7cd114b3c11730a1b8b71d89b64f9d033dfe0710f2364ef65645683381e2701173c08ff8625a0b0bc65bb3c3e0de46c80fdb2735e37652425489b65a283f043d
+  languageName: node
+  linkType: hard
+
+"@azure/core-util@npm:^1.0.0, @azure/core-util@npm:^1.11.0, @azure/core-util@npm:^1.4.0":
+  version: 1.11.0
+  resolution: "@azure/core-util@npm:1.11.0"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/245c93ec7fb3f2cb3a0b2f3a3be8d02ee401acba3cdd71620aa9e4e3ca50d831849f692332327bdbe1238ab979a76218f16a5166488ee31d5b67004298d110a3
+  languageName: node
+  linkType: hard
+
+"@azure/logger@npm:^1.0.0, @azure/logger@npm:^1.0.3":
+  version: 1.1.4
+  resolution: "@azure/logger@npm:1.1.4"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/5bc7792ef334e18f4893814e83cc61780a0effb927ba898095c75df1a01e1f3093dc7a63b6de549694cef76c25f43db850b82a48ec0fab5f9f1c1d2053af791d
+  languageName: node
+  linkType: hard
+
+"@azure/openai@npm:1.0.0-beta.12":
+  version: 1.0.0-beta.12
+  resolution: "@azure/openai@npm:1.0.0-beta.12"
+  dependencies:
+    "@azure-rest/core-client": "npm:^1.1.7"
+    "@azure/core-auth": "npm:^1.4.0"
+    "@azure/core-rest-pipeline": "npm:^1.13.0"
+    "@azure/core-sse": "npm:^2.0.0"
+    "@azure/core-util": "npm:^1.4.0"
+    "@azure/logger": "npm:^1.0.3"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/b132630c8a74a444b44a6dc1daaa362bc9a30b9f3a020f78af753bcd3820178adfc99a20fe3fd6027141e5d68018569c111e37a5df355d7de6e2f6f4968909b5
   languageName: node
   linkType: hard
 
@@ -7588,7 +7691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1":
+"https-proxy-agent@npm:^7.0.0, https-proxy-agent@npm:^7.0.1":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -11196,7 +11299,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.6.2, tslib@npm:^2.6.3":
+"tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62


### PR DESCRIPTION
more details on #71 
added this feature as a perimeter to search, so need to run the notebook with same doc again, if possible add the tldr comparing scores of both standard and HyDE search 

need to do
- add git secrets for aws key and id, aslo the gpt-40 deployment url and key from azure