### PR TITLE
Raw text input

### DIFF
--- a/src/api/search/api-search-schemas.ts
+++ b/src/api/search/api-search-schemas.ts
@@ -21,7 +21,7 @@ export const documentLinkBodySchema = Type.Object(
               {},
               {
                 description:
-                  'Any metadata related to the document. This is not used for the search of filtering',
+                  'Any metadata related to the document. This is not used for the search or filtering',
               },
             ),
           ),
@@ -63,6 +63,67 @@ export const documentLinkBodySchema = Type.Object(
   },
 );
 export type DocumentLinkBody = Static<typeof documentLinkBodySchema>;
+
+export const ingestRawBodySchema = Type.Object(
+  {
+    documents: Type.Array(
+      Type.Object(
+        {
+          content: Type.String({
+            description:
+              'The content of the document in plain text. Ideally formatted as markdown',
+          }),
+          documentID: Type.String({
+            description:
+              'The ID of the document. **Note** This id can only support letters, numbers, dashes (-) and underscores (_)',
+          }),
+          metadata: Type.Optional(
+            Type.Object(
+              {},
+              {
+                description:
+                  'Any metadata related to the document. This is not used for the search or filtering',
+              },
+            ),
+          ),
+          title: Type.Optional(
+            Type.String({
+              description: 'The title of the document, if any',
+            }),
+          ),
+        },
+        {
+          description: 'An array of document to ingest in plain text.',
+        },
+      ),
+    ),
+  },
+  {
+    additionalProperties: false,
+    examples: [
+      {
+        documents: [
+          {
+            content: '# A test document\nhello world',
+            documentID: 'abc-123',
+            metadata: { meta: 'data' },
+            title: 'File 1',
+          },
+          {
+            content: 'Another test document',
+            documentID: 'def-456',
+          },
+          {
+            content: 'and another one with more metadata',
+            documentID: 'def-789',
+            metadata: { meta: 'data' },
+          },
+        ],
+      },
+    ],
+  },
+);
+export type IngestRawBody = Static<typeof ingestRawBodySchema>;
 
 export const searchBodySchema = Type.Object(
   {

--- a/src/api/search/api-search-schemas.ts
+++ b/src/api/search/api-search-schemas.ts
@@ -157,7 +157,7 @@ export const searchResponseSchema = Type.Object(
               '(Optional) the highlight of the document/Closest match. This is to be used in RAG or to display the relevant part of the document to the user',
           }),
         ),
-        metadata: Type.Optional(Type.Object({})),
+        metadata: Type.Optional(Type.Any({})),
         score: Type.Number({
           description:
             'The search score of the document. This score can be higher than 1',

--- a/src/core/core-extractor.ts
+++ b/src/core/core-extractor.ts
@@ -1,11 +1,43 @@
-// utils
-import { downloadDocument } from '../utils/utils-downloader.js';
+// schemas
+import type {
+  DocumentLinkBody,
+  IngestRawBody,
+} from '../api/search/api-search-schemas.js';
 
 // parser
 import { parseStream } from '../parser/parser.ee.js';
+// utils
+import { downloadDocument } from '../utils/utils-downloader.js';
 
 /**
- * Download a document from the given url
+ * Dispatch the document to the correct extractor depending on the API body shape
+ * @param root named parameters
+ * @param root.document the document from the request body
+ * @returns string: the content of the document as a string
+ */
+export async function extractContent({
+  document,
+}: {
+  document:
+    | DocumentLinkBody['documents'][number]
+    | IngestRawBody['documents'][number];
+}): Promise<string> {
+  if ('url' in document && 'content' in document) {
+    throw new Error('Invalid document');
+  }
+
+  if ('url' in document) {
+    return extractFromUrl({ url: document.url });
+  }
+  if ('content' in document) {
+    return document.content;
+  }
+
+  throw new Error('Invalid document');
+}
+
+/**
+ * Download a document from the given url.
  * @param root named parameters
  * @param root.url the presigned url of the document to download
  * @returns the content of the document

--- a/src/core/tests/unit/core-extractor-unit.test.ts
+++ b/src/core/tests/unit/core-extractor-unit.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, test, vi } from 'vitest';
 
 // function to test
-import { extractFromUrl } from '../../core-extractor.js';
+import { extractContent, extractFromUrl } from '../../core-extractor.js';
 
 // mocks
 vi.mock('../../../utils/utils-downloader.js');
@@ -30,5 +30,73 @@ describe('extractFromUrl', async () => {
     expect(result).toEqual('test');
     expect(downloaderModule.downloadDocument).toHaveBeenCalledOnce();
     expect(parserModule.parseStream).toHaveBeenCalledOnce();
+  });
+});
+
+describe('extractContent', async () => {
+  test('should extract content when document has URL property', async () => {
+    downloaderModule.downloadDocument = vi
+      .fn()
+      .mockResolvedValue(
+        Buffer.from('test') satisfies Awaited<
+          ReturnType<typeof downloaderModule.downloadDocument>
+        >,
+      );
+    parserModule.parseStream = vi
+      .fn()
+      .mockResolvedValue(
+        'test' satisfies Awaited<ReturnType<typeof parserModule.parseStream>>,
+      );
+
+    const result = await extractContent({
+      document: {
+        documentID: 'test',
+        url: 'https://example.com',
+      },
+    });
+
+    expect(result).toEqual('test');
+    expect(downloaderModule.downloadDocument).toHaveBeenCalledOnce();
+    expect(parserModule.parseStream).toHaveBeenCalledOnce();
+  });
+
+  test('should extract content when document has content property', async () => {
+    downloaderModule.downloadDocument = vi.fn();
+    parserModule.parseStream = vi.fn();
+
+    const result = await extractContent({
+      document: {
+        content: 'my test content',
+        documentID: 'test',
+      },
+    });
+
+    expect(result).toEqual('my test content');
+
+    expect(downloaderModule.downloadDocument).not.toHaveBeenCalled();
+    expect(parserModule.parseStream).not.toHaveBeenCalled();
+  });
+
+  test('should throw an error when document has neither url nor content properties', async () => {
+    await expect(
+      extractContent({
+        // @ts-expect-error this is the behavior we want to test
+        document: {
+          documentID: 'test',
+        },
+      }),
+    ).rejects.toThrow('Invalid document');
+  });
+
+  test('should throw an error when document has both url and content properties', async () => {
+    await expect(
+      extractContent({
+        document: {
+          content: 'my test content',
+          documentID: 'test',
+          url: 'https://example.com',
+        },
+      }),
+    ).rejects.toThrow('Invalid document');
   });
 });


### PR DESCRIPTION
This PR adds an endpoint at `/ingest/raw` to allow inserting documents directly in plain text

like this:
`POST /ingest/raw mystring`

This was needed in the job agent demo repository to ingest documents directly, without having a step where the document is saved somewhere. 