### PR TITLE
add endpoint for multipart data upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@fastify/compress": "^8.0.1",
     "@fastify/cors": "^10.0.2",
     "@fastify/helmet": "^13.0.1",
+    "@fastify/multipart": "^9.0.2",
     "@fastify/swagger": "^9.4.1",
     "@fastify/swagger-ui": "^5.2.1",
     "@fastify/type-provider-typebox": "^5.1.0",

--- a/src/api/api-config.ts
+++ b/src/api/api-config.ts
@@ -1,6 +1,7 @@
 /* v8 ignore start */
 // libs
 /* eslint-disable import-x/no-named-as-default -- this is from libraries */
+import multipart from '@fastify/multipart';
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 /* eslint-enable import-x/no-named-as-default -- this is from libraries */
@@ -18,6 +19,7 @@ import { searchRouter } from './search/api-search-routes.js';
 
 // server
 export const app = await setupServer();
+await app.register(multipart);
 
 // documentation (dev only)
 if (process.env.NODE_ENV === 'development' || process.env.SHOW_DOC === 'true') {

--- a/src/api/api-schemas.ts
+++ b/src/api/api-schemas.ts
@@ -209,3 +209,14 @@ export const searchGetDocumentResponse = Type.Object(
 export type SearchGetDocumentResponse = Static<
   typeof searchGetDocumentResponse
 >;
+
+export const uploadFileResponseSchema = Type.Object({
+  files: Type.Array(
+    Type.Object({
+      documentID: Type.String(),
+      filename: Type.String(),
+      status: Type.String({ examples: ['uploaded'] }),
+    }),
+  ),
+  message: Type.String({ examples: ['Files uploaded successfully'] }),
+});

--- a/src/api/ingest/api-ingest-routes.ts
+++ b/src/api/ingest/api-ingest-routes.ts
@@ -193,43 +193,20 @@ Ideally your text should be in markdown format, to help with context extraction.
         description: `
 Upload multiple files and specify a unique documentID for each file.
 
-**Form field 1**: documents - A JSON array describing the metadata for each file, including documentID. For example:
+The form has two fields, one for the files metadata, and one for the files themselves.
+
+- **'documents'**: This field is for adding metadata, which is a JSON array. Each object in the array represents the metadata for a corresponding file. For example:
   \`\`\`json
   [
-    { "documentID": "doc-1", "metadata": { "key": "value1" } },
-    { "documentID": "doc-2" }
+    { "documentID": "doc-1", "metadata": { "key": "value1" }, "title": "File 1" },
+    { "documentID": "doc-2", "title": "File 2" }
   ]
   \`\`\`
 
-**Form field 2..N**: file (multiple files) - Each file corresponds to an entry in the documents array.
+- **'files'**: This field contains the files to be uploaded. It supports uploading multiple files, with each file corresponding to an entry in the 'documents' array.
 
 documents.length must equal the number of files uploaded.
 `,
-        requestBody: {
-          content: {
-            'multipart/form-data': {
-              schema: {
-                properties: {
-                  documents: {
-                    description:
-                      'A JSON string describing metadata for each file.',
-                    example:
-                      '[{"documentID":"doc-1","metadata":{"key":"value1"},"title":"File 1"}]',
-                    type: 'string',
-                  },
-                  file: {
-                    description: 'The file to upload.',
-                    format: 'binary',
-                    type: 'string',
-                  },
-                },
-                required: ['documents', 'file'],
-                type: 'object',
-              },
-            },
-          },
-          required: true,
-        },
         response: {
           200: uploadFileResponseSchema,
         },

--- a/src/api/ingest/api-ingest-routes.ts
+++ b/src/api/ingest/api-ingest-routes.ts
@@ -20,7 +20,7 @@ import { usageStatsFTS } from '../../database/search/database-search-fts.js';
 import { usageStatsVector } from '../../database/search/database-search-vector.js';
 
 // parser
-import { isFileSupported } from '../../parser/parser.ee.js';
+import { isFileSupported, parseStream } from '../../parser/parser.ee.js';
 
 // utils
 import { getTotalMemoryUsage } from '../../utils/utils-apm.js';
@@ -31,6 +31,7 @@ import {
   basicResponseSchema,
   documentLinkBodySchema,
   ingestRawBodySchema,
+  uploadFileResponseSchema,
 } from '../api-schemas.js';
 
 // /**
@@ -182,4 +183,142 @@ Ideally your text should be in markdown format, to help with context extraction.
       return { message: 'ok' };
     },
   );
+
+  app.post(
+    '/ingest/multipart',
+    {
+      onRequest: [app.token_auth],
+      schema: {
+        description: `
+Upload multiple files and specify a unique documentID for each file.
+
+**Form field 1**: documents - A JSON array describing the metadata for each file, including documentID. For example:
+  \`\`\`json
+  [
+    { "documentID": "doc-1", "metadata": { "key": "value1" } },
+    { "documentID": "doc-2" }
+  ]
+  \`\`\`
+
+**Form field 2..N**: file (multiple files) - Each file corresponds to an entry in the documents array.
+
+documents.length must equal the number of files uploaded.
+      `,
+        response: { 200: uploadFileResponseSchema },
+        security: [{ bearerAuth: [] }],
+        tags: ['ingest'],
+      },
+    },
+    async (request, reply) => {
+      const parts = request.parts();
+
+      let documentsFromBody: {
+        documentID: string;
+        metadata?: unknown;
+        title?: string;
+      }[] = [];
+      const fileBuffers: {
+        buffer: Buffer;
+        fieldname: string;
+        filename: string;
+        mimetype: string;
+      }[] = [];
+
+      for await (const part of parts) {
+        if (part.type === 'file') {
+          const chunks: Uint8Array[] = [];
+          for await (const chunk of part.file) {
+            if (chunk instanceof Uint8Array) {
+              chunks.push(chunk);
+            } else {
+              throw new TypeError('Invalid chunk type, expected Uint8Array');
+            }
+          }
+          const buffer = Buffer.concat(chunks);
+
+          fileBuffers.push({
+            buffer,
+            fieldname: part.fieldname,
+            filename: part.filename,
+            mimetype: part.mimetype,
+          });
+        } else if (part.fieldname === 'documents') {
+          if (typeof part.value !== 'string') {
+            return reply.status(400).send({
+              message: 'Invalid type for "documents" field. Expected string.',
+            });
+          }
+          try {
+            documentsFromBody = JSON.parse(part.value) as DocumentUpload[];
+          } catch {
+            return reply.status(400).send({
+              message: 'Invalid JSON in "documents" field',
+            });
+          }
+        }
+      }
+
+      if (documentsFromBody.length !== fileBuffers.length) {
+        return reply.status(400).send({
+          message: `Number of files (${fileBuffers.length}) does not match the length of the "documents" array (${documentsFromBody.length}).`,
+        });
+      }
+
+      for (const document of documentsFromBody) {
+        try {
+          await secureVerifyDocumentID({ documentID: document.documentID });
+        } catch {
+          return reply.status(422).send({
+            message:
+              'Forbidden characters found in document ID: ' +
+              document.documentID,
+          });
+        }
+      }
+
+      const uploadResults: {
+        documentID: string;
+        filename: string;
+        status: string;
+      }[] = [];
+
+      for (const [
+        index,
+        { buffer, filename, mimetype },
+      ] of fileBuffers.entries()) {
+        const { documentID, metadata, title } = documentsFromBody[index];
+
+        const content = await parseStream({
+          binaryStream: buffer,
+          documentName: filename,
+          mimeType: mimetype,
+        });
+
+        await addDocuments({
+          documents: [
+            {
+              content,
+              documentID,
+              metadata: metadata ?? {},
+              title: title ?? filename,
+            },
+          ],
+        });
+
+        uploadResults.push({
+          documentID,
+          filename,
+          status: 'uploaded',
+        });
+      }
+
+      return { files: uploadResults, message: 'Files uploaded successfully' };
+    },
+  );
 };
+
+interface DocumentUpload {
+  documentID: string;
+  metadata?: unknown;
+  title?: string;
+}

--- a/src/api/ingest/api-ingest-routes.ts
+++ b/src/api/ingest/api-ingest-routes.ts
@@ -189,6 +189,7 @@ Ideally your text should be in markdown format, to help with context extraction.
     {
       onRequest: [app.token_auth],
       schema: {
+        consumes: ['multipart/form-data'],
         description: `
 Upload multiple files and specify a unique documentID for each file.
 
@@ -203,8 +204,35 @@ Upload multiple files and specify a unique documentID for each file.
 **Form field 2..N**: file (multiple files) - Each file corresponds to an entry in the documents array.
 
 documents.length must equal the number of files uploaded.
-      `,
-        response: { 200: uploadFileResponseSchema },
+`,
+        requestBody: {
+          content: {
+            'multipart/form-data': {
+              schema: {
+                properties: {
+                  documents: {
+                    description:
+                      'A JSON string describing metadata for each file.',
+                    example:
+                      '[{"documentID":"doc-1","metadata":{"key":"value1"},"title":"File 1"}]',
+                    type: 'string',
+                  },
+                  file: {
+                    description: 'The file to upload.',
+                    format: 'binary',
+                    type: 'string',
+                  },
+                },
+                required: ['documents', 'file'],
+                type: 'object',
+              },
+            },
+          },
+          required: true,
+        },
+        response: {
+          200: uploadFileResponseSchema,
+        },
         security: [{ bearerAuth: [] }],
         tags: ['ingest'],
       },

--- a/src/parser/parser.ee.ts
+++ b/src/parser/parser.ee.ts
@@ -70,7 +70,10 @@ export async function parseStream({
     throw new Error('Unsupported document type' + documentName);
   }
 
-  const resolvedMimeType = mimeType ?? (await getMimeType({ documentName }));
+  const resolvedMimeType =
+    mimeType === 'application/octet-stream' || !mimeType
+      ? await getMimeType({ documentName })
+      : mimeType;
 
   switch (resolvedMimeType) {
     // Open Office XML

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,6 +57,7 @@ __metadata:
     "@fastify/compress": "npm:^8.0.1"
     "@fastify/cors": "npm:^10.0.2"
     "@fastify/helmet": "npm:^13.0.1"
+    "@fastify/multipart": "npm:^9.0.2"
     "@fastify/swagger": "npm:^9.4.1"
     "@fastify/swagger-ui": "npm:^5.2.1"
     "@fastify/type-provider-typebox": "npm:^5.1.0"
@@ -2522,6 +2523,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fastify/busboy@npm:^3.0.0":
+  version: 3.1.1
+  resolution: "@fastify/busboy@npm:3.1.1"
+  checksum: 10c0/d34b3640bc331f9951e27426769bdf90b1a5c238a22e4df39f9b18ec4cf793100a929ac0339f6643a4086f780f49177a528936d918dfd6c9dfe5a12566303215
+  languageName: node
+  linkType: hard
+
 "@fastify/compress@npm:^8.0.1":
   version: 8.0.1
   resolution: "@fastify/compress@npm:8.0.1"
@@ -2545,6 +2553,13 @@ __metadata:
     fastify-plugin: "npm:^5.0.0"
     mnemonist: "npm:0.39.8"
   checksum: 10c0/2d95e6580a9ac3258dc1bdbd3d5f52ff7c5e310c52640baa06230b8fd137b3c502615d3f55892d09df440c0451501e942af098e65d74db5235da9ea380eb99ca
+  languageName: node
+  linkType: hard
+
+"@fastify/deepmerge@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "@fastify/deepmerge@npm:2.0.1"
+  checksum: 10c0/043c7e5e028d01b4bdd6b99588e8f82e5b91399d68bcbcf11726c2d058faf6f0fdeecad837dded1e184430938cf29cfc65ae0d0ac4872ee865d32f6a3e86681f
   languageName: node
   linkType: hard
 
@@ -2587,6 +2602,19 @@ __metadata:
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
   checksum: 10c0/7979ce12724f7b98aea06f0bb9afb20dd869f0ff6fc697517135cbb54e0a36b062cbb38ec176fe43d1fc455576839240df8f33533939ace2d64a6218a6e6b9c1
+  languageName: node
+  linkType: hard
+
+"@fastify/multipart@npm:^9.0.2":
+  version: 9.0.2
+  resolution: "@fastify/multipart@npm:9.0.2"
+  dependencies:
+    "@fastify/busboy": "npm:^3.0.0"
+    "@fastify/deepmerge": "npm:^2.0.0"
+    "@fastify/error": "npm:^4.0.0"
+    fastify-plugin: "npm:^5.0.0"
+    secure-json-parse: "npm:^3.0.0"
+  checksum: 10c0/07ff513077b4d6120d29c1bc76e72e570bd49aa1bf30b12286bf399aafeee3fcad228172ecd4b2ff53c13e26f82cdafb5e04b8739280a9bc4479f5169a082b3e
   languageName: node
   linkType: hard
 
@@ -9759,7 +9787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"secure-json-parse@npm:^3.0.1":
+"secure-json-parse@npm:^3.0.0, secure-json-parse@npm:^3.0.1":
   version: 3.0.2
   resolution: "secure-json-parse@npm:3.0.2"
   checksum: 10c0/4c9c005e7fdd8528df35fcdec41dc4e8e15820ce52de19f8102da808f9400a9ed8c0a28971e3efe24b001ee1e60296af553f12bbaab81a152f702dd00af2092d


### PR DESCRIPTION
Hi,

This PR adds support for file uploads via a multipart endpoint. It allows users to upload files along with their associated documentID, which is then processed and stored for further use. There are a couple of points I’d like to clarify regarding this implementation:

**1. Document ID Assignment:**
Currently, this implementation allows uploading one file at a time, with a documentID provided for each file. However, if we want to support uploading multiple files in a single request, there's no clear way to assign a unique documentID to each file. I’d like to confirm: should we maintain the current approach where users manually provide a documentID for each file?

**2. File Storage Location:**
Regarding file uploads, Fastify requires that files be stored in a specific way (e.g., using temporary directories or streams). In the current implementation, files are directly processed as streams in memory, and no files are written to disk. Would it be preferable to store uploaded files in a temporary location before processing, or is the current memory-based approach acceptable?

Thanks. This PR will fix #73 