### PR TITLE
add temporaty storage and queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@fastify/compress": "^8.0.1",
     "@fastify/cors": "^10.0.2",
     "@fastify/helmet": "^13.0.1",
-    "@fastify/multipart": "^9.0.2",
+    "@fastify/multipart": "^9.0.3",
     "@fastify/swagger": "^9.4.1",
     "@fastify/swagger-ui": "^5.2.1",
     "@fastify/type-provider-typebox": "^5.1.0",

--- a/src/core/core-upload-queue.ts
+++ b/src/core/core-upload-queue.ts
@@ -1,0 +1,58 @@
+import type { QueueItem } from '../database/queue/database-queue.js';
+import { queueAdd, queueGetNext } from '../database/queue/database-queue.js';
+
+import {
+  readTemporaryMetadata,
+  readTemporaryText,
+  storeTextAndMetadata,
+} from '../database/temp/database-temporary.js';
+
+/**
+ * Prepares a document for later processing.
+ * @param documentID A unique string identifier for the document.
+ * @param text The document content (plain text or raw text).
+ * @param metadata Arbitrary metadata to store alongside the document.
+ */
+export async function addItemForLaterProcessing(
+  documentID: string,
+  text: string,
+  metadata: unknown,
+): Promise<void> {
+  await storeTextAndMetadata(documentID, text, metadata);
+
+  const queueItem: QueueItem = {
+    createdAt: Date.now(),
+    documentID,
+  };
+
+  await queueAdd(queueItem);
+}
+
+/**
+ * Retrieves the next item from the queue (FIFO)
+ * @returns An object containing the document ID, text, and metadata or undefined if the queue is empty.
+ */
+export async function getNextItemToProcess(): Promise<
+  | undefined
+  | {
+      documentID: string;
+      metadata: unknown;
+      text: string;
+    }
+> {
+  const item = await queueGetNext();
+  if (!item) {
+    return undefined;
+  }
+
+  const [documentText, documentMetadata] = await Promise.all([
+    readTemporaryText(item.documentID),
+    readTemporaryMetadata(item.documentID),
+  ]);
+
+  return {
+    documentID: item.documentID,
+    metadata: documentMetadata,
+    text: documentText,
+  };
+}

--- a/src/core/tests/integration/core-upload-queue-integration.test.ts
+++ b/src/core/tests/integration/core-upload-queue-integration.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import {
+  loadQueue,
+  saveQueue,
+} from '../../../database/queue/database-queue.js';
+import {
+  readTemporaryMetadata,
+  readTemporaryText,
+} from '../../../database/temp/database-temporary.js';
+import {
+  addItemForLaterProcessing,
+  getNextItemToProcess,
+} from '../../core-upload-queue.js';
+
+const TEST_BASE_FOLDER = path.join(process.cwd(), '.testMemoire');
+
+const TEMP_PATH = path.join(TEST_BASE_FOLDER, 'temp');
+const QUEUE_PATH = path.join(TEST_BASE_FOLDER, 'queue');
+
+describe('Upload Queue Integration Tests', () => {
+  beforeAll(async () => {
+    await fs.mkdir(TEMP_PATH, { recursive: true });
+    await fs.mkdir(QUEUE_PATH, { recursive: true });
+
+    await loadQueue();
+  });
+
+  afterAll(async () => {
+    await saveQueue();
+
+    await fs.rm(TEST_BASE_FOLDER, { force: true, recursive: true });
+  });
+
+  test('Add one document and retrieve it from the queue', async () => {
+    const documentId = 'int-doc-1';
+    const text = 'Integration test content';
+    const metadata = { meta: 'integration' };
+
+    await addItemForLaterProcessing(documentId, text, metadata);
+
+    const storedText = await readTemporaryText(documentId);
+    const storedMetadata = await readTemporaryMetadata(documentId);
+
+    expect(storedText).toBe(text);
+    expect(storedMetadata).toEqual(metadata);
+
+    const nextItem = await getNextItemToProcess();
+    expect(nextItem).toBeDefined();
+    if (!nextItem) return;
+
+    expect(nextItem.documentID).toBe(documentId);
+    expect(nextItem.text).toBe(text);
+    expect(nextItem.metadata).toEqual(metadata);
+
+    const noItemLeft = await getNextItemToProcess();
+    expect(noItemLeft).toBeUndefined();
+  });
+
+  test('Add multiple items, retrieve them in FIFO order', async () => {
+    await addItemForLaterProcessing('fifo-doc-1', 'hello 1', { a: 1 });
+    await addItemForLaterProcessing('fifo-doc-2', 'hello 2', { b: 2 });
+
+    const first = await getNextItemToProcess();
+    expect(first?.documentID).toBe('fifo-doc-1');
+
+    const second = await getNextItemToProcess();
+    expect(second?.documentID).toBe('fifo-doc-2');
+
+    const third = await getNextItemToProcess();
+    expect(third).toBeUndefined();
+  });
+});

--- a/src/core/tests/unit/core-upload-queue-unit.test.ts
+++ b/src/core/tests/unit/core-upload-queue-unit.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import * as queueModule from '../../../database/queue/database-queue.js';
+import * as temporaryModule from '../../../database/temp/database-temporary.js';
+import {
+  addItemForLaterProcessing,
+  getNextItemToProcess,
+} from '../../core-upload-queue.js';
+
+describe('Upload Queue Unit Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('addItemForLaterProcessing calls storeTextAndMetadata & queueAdd', async () => {
+    vi.spyOn(temporaryModule, 'storeTextAndMetadata').mockResolvedValue(
+      undefined,
+    );
+    vi.spyOn(queueModule, 'queueAdd').mockResolvedValue(undefined);
+
+    await addItemForLaterProcessing('doc-1', 'fake content', {
+      some: 'metadata',
+    });
+
+    expect(temporaryModule.storeTextAndMetadata).toHaveBeenCalledTimes(1);
+    expect(temporaryModule.storeTextAndMetadata).toHaveBeenCalledWith(
+      'doc-1',
+      'fake content',
+      { some: 'metadata' },
+    );
+
+    expect(queueModule.queueAdd).toHaveBeenCalledTimes(1);
+    expect(queueModule.queueAdd).toHaveBeenCalledWith({
+      createdAt: expect.any(Number),
+      documentID: 'doc-1',
+    });
+  });
+
+  test('getNextItemToProcess returns undefined if queue is empty', async () => {
+    vi.spyOn(queueModule, 'queueGetNext').mockResolvedValue(undefined);
+
+    vi.spyOn(temporaryModule, 'readTemporaryText');
+    vi.spyOn(temporaryModule, 'readTemporaryMetadata');
+
+    const result = await getNextItemToProcess();
+    expect(result).toBeUndefined();
+
+    expect(queueModule.queueGetNext).toHaveBeenCalledTimes(1);
+    expect(temporaryModule.readTemporaryText).not.toHaveBeenCalled();
+    expect(temporaryModule.readTemporaryMetadata).not.toHaveBeenCalled();
+  });
+
+  test('getNextItemToProcess reads files if queue item exists', async () => {
+    vi.spyOn(queueModule, 'queueGetNext').mockResolvedValue({
+      createdAt: 123,
+      documentID: 'doc-1',
+    });
+    vi.spyOn(temporaryModule, 'readTemporaryText').mockResolvedValue(
+      'Some text',
+    );
+    vi.spyOn(temporaryModule, 'readTemporaryMetadata').mockResolvedValue({
+      foo: 'bar',
+    });
+
+    const result = await getNextItemToProcess();
+
+    expect(queueModule.queueGetNext).toHaveBeenCalledTimes(1);
+    expect(temporaryModule.readTemporaryText).toHaveBeenCalledWith('doc-1');
+    expect(temporaryModule.readTemporaryMetadata).toHaveBeenCalledWith('doc-1');
+
+    expect(result).toEqual({
+      documentID: 'doc-1',
+      metadata: { foo: 'bar' },
+      text: 'Some text',
+    });
+  });
+});

--- a/src/database/queue/database-queue.ts
+++ b/src/database/queue/database-queue.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const isTestEnvironment = process.env.NODE_ENV === 'test';
+export const BASE_FOLDER = isTestEnvironment ? '.testMemoire' : 'data';
+const QUEUE_FILE_PATH = path.join(
+  process.cwd(),
+  BASE_FOLDER,
+  'queue',
+  'queue.json',
+);
+
+export interface QueueItem {
+  createdAt: number;
+  documentID: string;
+}
+
+/**
+ * A custom interface for errors that may have an optional code property.
+ */
+interface NodeJsErrorWithCode extends Error {
+  code?: string;
+}
+
+/**
+ * In-memory queue (FIFO), reloaded from disk on startup.
+ */
+let inMemoryQueue: QueueItem[] = [];
+
+/**
+ * Loads the queue from the disk into memory.
+ * If file doesn't exist, we initialize an empty queue.
+ */
+export async function loadQueue(): Promise<void> {
+  await ensureQueueFolder();
+  try {
+    const buffer = await fs.readFile(QUEUE_FILE_PATH);
+    const content = buffer.toString('utf8');
+    const parsed = JSON.parse(content) as unknown;
+
+    if (!Array.isArray(parsed)) {
+      throw new TypeError('Queue JSON is not an array.');
+    }
+
+    for (const item of parsed) {
+      if (!isQueueItem(item)) {
+        throw new Error(`Queue JSON has invalid item: ${JSON.stringify(item)}`);
+      }
+    }
+
+    inMemoryQueue = parsed as QueueItem[];
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      const nodeError = error as NodeJsErrorWithCode;
+      if (nodeError.code === 'ENOENT') {
+        inMemoryQueue = [];
+        return;
+      }
+    }
+    throw error;
+  }
+}
+
+/**
+ * Adds a new item to the end of the queue.
+ * @param item The item to add.
+ */
+export async function queueAdd(item: QueueItem): Promise<void> {
+  inMemoryQueue.push(item);
+  await saveQueue();
+}
+
+/**
+ * Retrieves the next item from the queue (FIFO).
+ * @returns The next QueueItem or undefined if the queue is empty.
+ */
+export async function queueGetNext(): Promise<QueueItem | undefined> {
+  const item = inMemoryQueue.shift();
+  await saveQueue();
+  return item;
+}
+
+/**
+ * Saves the current in-memory queue to disk.
+ */
+export async function saveQueue(): Promise<void> {
+  await ensureQueueFolder();
+  const json = JSON.stringify(inMemoryQueue, undefined, 2);
+  await fs.writeFile(QUEUE_FILE_PATH, json, 'utf8');
+}
+
+/**
+ * Ensure the queue folder exists; create it if necessary.
+ */
+async function ensureQueueFolder(): Promise<void> {
+  const directory = path.dirname(QUEUE_FILE_PATH);
+  await fs.mkdir(directory, { recursive: true });
+}
+
+/**
+ * A type guard function to verify the object matches the QueueItem interface.
+ * @param object The object to check.
+ * @returns A boolean indicating whether the object is a valid QueueItem.
+ */
+function isQueueItem(object: unknown): object is QueueItem {
+  if (typeof object !== 'object' || object === null) {
+    return false;
+  }
+
+  const record = object as { [key: string]: unknown };
+  return (
+    typeof record.documentID === 'string' &&
+    typeof record.createdAt === 'number'
+  );
+}

--- a/src/database/queue/test/unit/database-queue-unit.test.ts
+++ b/src/database/queue/test/unit/database-queue-unit.test.ts
@@ -46,7 +46,12 @@ describe('Database Queue', () => {
     await queueAdd({ createdAt: 123, documentID: 'doc-1' });
 
     expect(fsPromises.writeFile).toHaveBeenCalledTimes(1);
-    const queuePath = path.join(process.cwd(), 'data', 'queue', 'queue.json');
+    const queuePath = path.join(
+      process.cwd(),
+      '.testMemoire',
+      'queue',
+      'queue.json',
+    );
     expect(fsPromises.writeFile).toHaveBeenCalledWith(
       queuePath,
       expect.any(String),

--- a/src/database/queue/test/unit/database-queue-unit.test.ts
+++ b/src/database/queue/test/unit/database-queue-unit.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+
+vi.mock('node:fs/promises');
+
+import { loadQueue, queueAdd, queueGetNext } from '../../database-queue.js';
+
+const fsPromises = fs;
+
+/**
+ * Creates an Error object with `code = 'ENOENT'` without using classes or Object.assign.
+ * @param message The error message to describe the file not found condition.
+ * @returns An Error object with a custom `code` property set to `'ENOENT'`.
+ */
+function createENOENTError(
+  message = 'File not found',
+): Error & { code: string } {
+  const error = new Error(message);
+  error.name = 'ENOENTError';
+  (error as Error & { code: string }).code = 'ENOENT';
+  return error as Error & { code: string };
+}
+
+describe('Database Queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('loadQueue will create an empty queue if the file does not exist (ENOENT)', async () => {
+    (fsPromises.readFile as Mock).mockRejectedValueOnce(createENOENTError());
+
+    await loadQueue();
+
+    expect(fsPromises.readFile).toHaveBeenCalledTimes(1);
+  });
+
+  test('loadQueue will throw error if JSON is not an array', async () => {
+    (fsPromises.readFile as Mock).mockResolvedValueOnce(
+      Buffer.from(JSON.stringify({ not: 'an array' })),
+    );
+    await expect(loadQueue()).rejects.toThrow('Queue JSON is not an array.');
+  });
+
+  test('queueAdd will push item in memory and call saveQueue', async () => {
+    await queueAdd({ createdAt: 123, documentID: 'doc-1' });
+
+    expect(fsPromises.writeFile).toHaveBeenCalledTimes(1);
+    const queuePath = path.join(process.cwd(), 'data', 'queue', 'queue.json');
+    expect(fsPromises.writeFile).toHaveBeenCalledWith(
+      queuePath,
+      expect.any(String),
+      'utf8',
+    );
+  });
+
+  test('queueGetNext will shift item from the queue and call saveQueue', async () => {
+    (fsPromises.readFile as Mock).mockResolvedValueOnce(
+      Buffer.from(JSON.stringify([{ createdAt: 123, documentID: 'doc-1' }])),
+    );
+    await loadQueue();
+
+    const item = await queueGetNext();
+    expect(item).toEqual({ createdAt: 123, documentID: 'doc-1' });
+
+    expect(fsPromises.writeFile).toHaveBeenCalled();
+  });
+});

--- a/src/database/temp/database-temporary.ts
+++ b/src/database/temp/database-temporary.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const isTestEnvironment = process.env.NODE_ENV === 'test';
+export const BASE_FOLDER = isTestEnvironment ? '.testMemoire' : 'data';
+const TEMP_FOLDER_PATH = path.join(process.cwd(), BASE_FOLDER, 'temp');
+
+/**
+ * Reads the metadata file for a given document ID.
+ * @param documentId The document ID.
+ * @returns The metadata object.
+ */
+export async function readTemporaryMetadata(
+  documentId: string,
+): Promise<unknown> {
+  const metadataPath = path.join(TEMP_FOLDER_PATH, `${documentId}.json`);
+  const buffer = await fs.readFile(metadataPath);
+  return JSON.parse(buffer.toString());
+}
+
+/**
+ * Reads the text file for a given document ID.
+ * @param documentId The document ID.
+ * @returns The content of the text file.
+ */
+export async function readTemporaryText(documentId: string): Promise<string> {
+  const textPath = path.join(TEMP_FOLDER_PATH, `${documentId}.txt`);
+  return fs.readFile(textPath, 'utf8');
+}
+
+/**
+ * Saves text and metadata as separate files in the temporary folder.
+ * @param documentId The document ID used as the file name prefix.
+ * @param text The document content.
+ * @param metadata The metadata object.
+ * @returns A promise indicating completion.
+ */
+export async function storeTextAndMetadata(
+  documentId: string,
+  text: string,
+  metadata: unknown,
+): Promise<void> {
+  await ensureTemporaryFolder();
+
+  const textPath = path.join(TEMP_FOLDER_PATH, `${documentId}.txt`);
+  const metadataPath = path.join(TEMP_FOLDER_PATH, `${documentId}.json`);
+
+  await fs.writeFile(textPath, text, 'utf8');
+  await fs.writeFile(
+    metadataPath,
+    JSON.stringify(metadata, undefined, 2),
+    'utf8',
+  );
+}
+
+/**
+ * Ensures the temporary folder exists, creating it if necessary.
+ * @returns A promise indicating completion.
+ */
+async function ensureTemporaryFolder(): Promise<void> {
+  await fs.mkdir(TEMP_FOLDER_PATH, { recursive: true });
+}

--- a/src/database/temp/test/unit/database-temporary-unit.test.ts
+++ b/src/database/temp/test/unit/database-temporary-unit.test.ts
@@ -26,20 +26,20 @@ describe('Database Temporary', () => {
 
     expect(fsPromises.mkdir).toHaveBeenCalledTimes(1);
     expect(fsPromises.mkdir).toHaveBeenCalledWith(
-      path.join(process.cwd(), 'data', 'temp'),
+      path.join(process.cwd(), '.testMemoire', 'temp'),
       { recursive: true },
     );
 
     expect(fsPromises.writeFile).toHaveBeenNthCalledWith(
       1,
-      path.join(process.cwd(), 'data', 'temp', `${documentId}.txt`),
+      path.join(process.cwd(), '.testMemoire', 'temp', `${documentId}.txt`),
       content,
       'utf8',
     );
 
     expect(fsPromises.writeFile).toHaveBeenNthCalledWith(
       2,
-      path.join(process.cwd(), 'data', 'temp', `${documentId}.json`),
+      path.join(process.cwd(), '.testMemoire', 'temp', `${documentId}.json`),
       JSON.stringify(metadata, undefined, 2),
       'utf8',
     );
@@ -49,7 +49,7 @@ describe('Database Temporary', () => {
     const documentId = 'test-doc';
     const expectedPath = path.join(
       process.cwd(),
-      'data',
+      '.testMemoire',
       'temp',
       `${documentId}.txt`,
     );
@@ -67,7 +67,7 @@ describe('Database Temporary', () => {
     const documentId = 'test-doc';
     const expectedPath = path.join(
       process.cwd(),
-      'data',
+      '.testMemoire',
       'temp',
       `${documentId}.json`,
     );

--- a/src/database/temp/test/unit/database-temporary-unit.test.ts
+++ b/src/database/temp/test/unit/database-temporary-unit.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+
+vi.mock('node:fs/promises');
+
+import {
+  readTemporaryMetadata,
+  readTemporaryText,
+  storeTextAndMetadata,
+} from '../../database-temporary.js';
+
+const fsPromises = fs;
+
+describe('Database Temporary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('storeTextAndMetadata writes .txt and .json files with correct paths', async () => {
+    const documentId = 'test-doc';
+    const content = 'Hello, world!';
+    const metadata = { foo: 'bar' };
+
+    await storeTextAndMetadata(documentId, content, metadata);
+
+    expect(fsPromises.mkdir).toHaveBeenCalledTimes(1);
+    expect(fsPromises.mkdir).toHaveBeenCalledWith(
+      path.join(process.cwd(), 'data', 'temp'),
+      { recursive: true },
+    );
+
+    expect(fsPromises.writeFile).toHaveBeenNthCalledWith(
+      1,
+      path.join(process.cwd(), 'data', 'temp', `${documentId}.txt`),
+      content,
+      'utf8',
+    );
+
+    expect(fsPromises.writeFile).toHaveBeenNthCalledWith(
+      2,
+      path.join(process.cwd(), 'data', 'temp', `${documentId}.json`),
+      JSON.stringify(metadata, undefined, 2),
+      'utf8',
+    );
+  });
+
+  test('readTemporaryText reads the correct .txt file', async () => {
+    const documentId = 'test-doc';
+    const expectedPath = path.join(
+      process.cwd(),
+      'data',
+      'temp',
+      `${documentId}.txt`,
+    );
+
+    (fsPromises.readFile as Mock).mockResolvedValue('fake text content');
+
+    const text = await readTemporaryText(documentId);
+
+    expect(fsPromises.readFile).toHaveBeenCalledTimes(1);
+    expect(fsPromises.readFile).toHaveBeenCalledWith(expectedPath, 'utf8');
+    expect(text).toBe('fake text content');
+  });
+
+  test('readTemporaryMetadata reads the correct .json file and parses it as JSON', async () => {
+    const documentId = 'test-doc';
+    const expectedPath = path.join(
+      process.cwd(),
+      'data',
+      'temp',
+      `${documentId}.json`,
+    );
+
+    (fsPromises.readFile as Mock).mockResolvedValue(
+      Buffer.from(JSON.stringify({ foo: 123 })),
+    );
+
+    const metadata = await readTemporaryMetadata(documentId);
+
+    expect(fsPromises.readFile).toHaveBeenCalledTimes(1);
+    expect(fsPromises.readFile).toHaveBeenCalledWith(expectedPath);
+    expect(metadata).toEqual({ foo: 123 });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,7 +57,7 @@ __metadata:
     "@fastify/compress": "npm:^8.0.1"
     "@fastify/cors": "npm:^10.0.2"
     "@fastify/helmet": "npm:^13.0.1"
-    "@fastify/multipart": "npm:^9.0.2"
+    "@fastify/multipart": "npm:^9.0.3"
     "@fastify/swagger": "npm:^9.4.1"
     "@fastify/swagger-ui": "npm:^5.2.1"
     "@fastify/type-provider-typebox": "npm:^5.1.0"
@@ -2605,16 +2605,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/multipart@npm:^9.0.2":
-  version: 9.0.2
-  resolution: "@fastify/multipart@npm:9.0.2"
+"@fastify/multipart@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "@fastify/multipart@npm:9.0.3"
   dependencies:
     "@fastify/busboy": "npm:^3.0.0"
     "@fastify/deepmerge": "npm:^2.0.0"
     "@fastify/error": "npm:^4.0.0"
     fastify-plugin: "npm:^5.0.0"
     secure-json-parse: "npm:^3.0.0"
-  checksum: 10c0/07ff513077b4d6120d29c1bc76e72e570bd49aa1bf30b12286bf399aafeee3fcad228172ecd4b2ff53c13e26f82cdafb5e04b8739280a9bc4479f5169a082b3e
+  checksum: 10c0/589571e71954e28b6445dcaeef3f4e978931f9a697cf259ef45327ee646f85db2195cd38fe4bf758aab3e0d61ceb30429b1389fd9e176f55a3c83b4186ebb20d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Hi, I've finished the following:

1. Implemented a core file to handle file uploads, saving text and metadata in temporary storage and managing a queue with FIFO order and persistence.
2. Added database functions for saving, reading, and managing documents and the queue.
3. Created interface functions for adding documents for processing and retrieving the next item.
4. Developed unit and integration tests.

Let me know if any adjustments are needed. Thanks.

This PR will fix #108 

