### PR TITLE
Add PostgreSQL for the storage of the queue

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,3 +9,4 @@ AWS_ACCESS_KEY_ID= # (optional) needed if you want to use cohere or titan from A
 AWS_REGION= # (optional) needed if you want to use cohere or titan from AWS bedrock
 OPENAI_LLM_KEY= # (optional) needed if you are using hyde/enhancedSemantic parameter
 OPENAI_LLM_DEPLOYMENT= # (optional) needed if you are using hyde/enhancedSemantic parameter, the URL for from your LLM deployment
+SUPABASE_URL= # (optional) needed if you want to connect to your Supabase database

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   },
   "type": "module",
   "dependencies": {
-    "pino-pretty": "^13.0.0"
+    "dotenv": "^16.4.7",
+    "drizzle-orm": "^0.39.1",
+    "postgres": "^3.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.39.1",
+    "pino-pretty": "^13.0.0",
     "postgres": "^3.4.5"
   }
 }

--- a/services/packages/database/src/document-queue/database-dq-interface.ts
+++ b/services/packages/database/src/document-queue/database-dq-interface.ts
@@ -1,4 +1,4 @@
-import type { QueueItem } from './database-dq-queue.js';
+import type { QueueItem } from './database-dq-queue-typebox-schema.js';
 import { queueAdd, queueGetNext } from './database-dq-queue.js';
 import {
   readTemporaryMetadata,

--- a/services/packages/database/src/document-queue/database-dq-queue-database-schema.ts
+++ b/services/packages/database/src/document-queue/database-dq-queue-database-schema.ts
@@ -1,0 +1,7 @@
+import { bigint, pgTable, serial, varchar } from 'drizzle-orm/pg-core';
+
+export const queueTable = pgTable('queue', {
+  createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+  documentID: varchar('document_id', { length: 255 }).notNull(),
+  id: serial('id').primaryKey(),
+});

--- a/services/packages/database/src/document-queue/database-dq-queue-typebox-schema.ts
+++ b/services/packages/database/src/document-queue/database-dq-queue-typebox-schema.ts
@@ -1,0 +1,9 @@
+import type { Static } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
+
+export const QueueItemSchema = Type.Object({
+  createdAt: Type.Number(),
+  documentID: Type.String(),
+});
+
+export type QueueItem = Static<typeof QueueItemSchema>;

--- a/services/packages/database/src/document-queue/database-dq.ts
+++ b/services/packages/database/src/document-queue/database-dq.ts
@@ -1,0 +1,17 @@
+import 'dotenv/config';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+
+const connectionString = process.env.SUPABASE_URL;
+
+let client: null | ReturnType<typeof postgres>;
+let databaseLocal: null | ReturnType<typeof drizzle>;
+
+if (connectionString) {
+  client = postgres(connectionString, { prepare: false });
+  databaseLocal = drizzle(client);
+} else {
+  /* empty */
+}
+
+export { client, databaseLocal as db };

--- a/services/packages/database/src/document-queue/test/integration/database-dq-interface-database-integration.test.ts
+++ b/services/packages/database/src/document-queue/test/integration/database-dq-interface-database-integration.test.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, describe, expect, test } from 'vitest';
+import {
+  getNextDocumentToProcess,
+  saveDocumentForLaterProcessing,
+} from '../../database-dq-interface.js';
+
+const TEST_MEMOIRE_PATH = path.join(process.cwd(), '.testMemoire');
+
+describe('Queue integration test (remote Supabase)', () => {
+  afterAll(async () => {
+    await fs.rm(TEST_MEMOIRE_PATH, { force: true, recursive: true });
+  });
+
+  test('Add and retrieve item from remote DB queue', async () => {
+    await saveDocumentForLaterProcessing({
+      documentID: 'remote-test-doc',
+      metadata: { db: 'supabase' },
+      text: 'Hello from remote supabase!',
+    });
+
+    const nextItem = await getNextDocumentToProcess();
+    expect(nextItem).toBeDefined();
+    if (!nextItem) return;
+
+    expect(nextItem.documentID).toBe('remote-test-doc');
+    expect(nextItem.metadata).toEqual({ db: 'supabase' });
+    expect(nextItem.text).toBe('Hello from remote supabase!');
+  });
+});

--- a/services/packages/database/src/document-queue/test/integration/database-dq-interface-fs-integration.test.ts
+++ b/services/packages/database/src/document-queue/test/integration/database-dq-interface-fs-integration.test.ts
@@ -1,3 +1,4 @@
+process.env.SUPABASE_URL = '';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';

--- a/services/packages/database/src/document-queue/test/unit/database-dq-queue-database-unit.test.ts
+++ b/services/packages/database/src/document-queue/test/unit/database-dq-queue-database-unit.test.ts
@@ -1,0 +1,147 @@
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type postgres from 'postgres';
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+
+vi.mock('node:fs/promises', () => {
+  return {
+    mkdir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  };
+});
+
+vi.mock('../../database-dq.js', () => {
+  return {
+    db: {
+      $client: {} as postgres.Sql,
+      delete: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      }),
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi
+              .fn()
+              .mockResolvedValue([
+                { createdAt: 123, documentID: 'doc-DB', id: 99 },
+              ]),
+          }),
+        }),
+      }),
+    } as unknown as PostgresJsDatabase<{ [key: string]: unknown }> & {
+      $client: postgres.Sql;
+    },
+  };
+});
+
+describe('Database Queue (DB Mode)', () => {
+  beforeAll(() => {
+    process.env.SUPABASE_URL = 'postgres://fakeUrl';
+    vi.resetModules();
+  });
+
+  afterAll(() => {
+    process.env.SUPABASE_URL = '';
+  });
+
+  test('queueAdd() will call db.insert(...) when DB is available', async () => {
+    const { queueAdd } = await import('../../database-dq-queue.js');
+    await queueAdd({ createdAt: 111, documentID: 'doc-1' });
+
+    const { db } = (await import('../../database-dq.js')) as {
+      db: PostgresJsDatabase<{ [key: string]: unknown }> & {
+        $client: postgres.Sql;
+      };
+    };
+    expect(db.insert).toHaveBeenCalledTimes(1);
+
+    const fs = await import('node:fs/promises');
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  test('queueGetNext() will call db.select(...) and db.delete(...) in DB mode', async () => {
+    const { queueGetNext } = await import('../../database-dq-queue.js');
+    const item = await queueGetNext();
+
+    const { db } = (await import('../../database-dq.js')) as {
+      db: PostgresJsDatabase<{ [key: string]: unknown }> & {
+        $client: postgres.Sql;
+      };
+    };
+    expect(db.select).toHaveBeenCalledTimes(1);
+    expect(db.delete).toHaveBeenCalledTimes(1);
+    expect(item).toEqual({
+      createdAt: 123,
+      documentID: 'doc-DB',
+    });
+
+    const fs = await import('node:fs/promises');
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  test('queueAdd() will throw error if DB insert fails', async () => {
+    const { queueAdd } = await import('../../database-dq-queue.js');
+    const { db } = (await import('../../database-dq.js')) as {
+      db: PostgresJsDatabase<{ [key: string]: unknown }> & {
+        $client: postgres.Sql;
+      };
+    };
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockRejectedValue(new Error('Database error')),
+    } as never);
+
+    await expect(
+      queueAdd({ createdAt: 111, documentID: 'doc-1' }),
+    ).rejects.toThrow('Database error');
+  });
+
+  test('queueGetNext() will return undefined if DB select returns empty', async () => {
+    const { queueGetNext } = await import('../../database-dq-queue.js');
+    const { db } = (await import('../../database-dq.js')) as {
+      db: PostgresJsDatabase<{ [key: string]: unknown }> & {
+        $client: postgres.Sql;
+      };
+    };
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    } as never);
+
+    const item = await queueGetNext();
+    expect(item).toBeUndefined();
+  });
+
+  test('queueGetNext() will return correct item from DB', async () => {
+    const { queueGetNext } = await import('../../database-dq-queue.js');
+    const { db } = (await import('../../database-dq.js')) as {
+      db: PostgresJsDatabase<{ [key: string]: unknown }> & {
+        $client: postgres.Sql;
+      };
+    };
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi
+            .fn()
+            .mockResolvedValue([
+              { createdAt: 456, documentID: 'doc-test', id: 100 },
+            ]),
+        }),
+      }),
+    } as never);
+
+    const item = await queueGetNext();
+    expect(item).toEqual({
+      createdAt: 456,
+      documentID: 'doc-test',
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,6 +88,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.0.1"
     eslint-import-resolver-typescript: "npm:^3.7.0"
     license-checker-rseidelsohn: "npm:^4.4.2"
+    pino-pretty: "npm:^13.0.0"
     postgres: "npm:^3.4.5"
     prettier: "npm:^3.4.2"
     tsup: "npm:^8.3.5"
@@ -5287,6 +5288,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"colorette@npm:^2.0.7":
+  version: 2.0.20
+  resolution: "colorette@npm:2.0.20"
+  checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
+  languageName: node
+  linkType: hard
+
 "combined-stream@npm:^1.0.8":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
@@ -5422,6 +5430,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     is-data-view: "npm:^1.0.1"
   checksum: 10c0/fa7aa40078025b7810dcffc16df02c480573b7b53ef1205aa6a61533011005c1890e5ba17018c692ce7c900212b547262d33279fde801ad9843edc0863bf78c4
+  languageName: node
+  linkType: hard
+
+"dateformat@npm:^4.6.3":
+  version: 4.6.3
+  resolution: "dateformat@npm:4.6.3"
+  checksum: 10c0/e2023b905e8cfe2eb8444fb558562b524807a51cdfe712570f360f873271600b5c94aebffaf11efb285e2c072264a7cf243eadb68f3eba0f8cc85fb86cd25df6
   languageName: node
   linkType: hard
 
@@ -6588,6 +6603,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-copy@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "fast-copy@npm:3.0.2"
+  checksum: 10c0/02e8b9fd03c8c024d2987760ce126456a0e17470850b51e11a1c3254eed6832e4733ded2d93316c82bc0b36aeb991ad1ff48d1ba95effe7add7c3ab8d8eb554a
+  languageName: node
+  linkType: hard
+
 "fast-decode-uri-component@npm:^1.0.1":
   version: 1.0.1
   resolution: "fast-decode-uri-component@npm:1.0.1"
@@ -6670,6 +6692,13 @@ __metadata:
   version: 3.5.0
   resolution: "fast-redact@npm:3.5.0"
   checksum: 10c0/7e2ce4aad6e7535e0775bf12bd3e4f2e53d8051d8b630e0fa9e67f68cb0b0e6070d2f7a94b1d0522ef07e32f7c7cda5755e2b677a6538f1e9070ca053c42343a
+  languageName: node
+  linkType: hard
+
+"fast-safe-stringify@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "fast-safe-stringify@npm:2.1.1"
+  checksum: 10c0/d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
   languageName: node
   linkType: hard
 
@@ -7177,6 +7206,13 @@ __metadata:
   version: 8.0.0
   resolution: "helmet@npm:8.0.0"
   checksum: 10c0/c3d273df206cbb4e5e830ea68afdbd3d0f8e055b2707f67f651ebb4b679c7fd4d6ac77ce6188a2cee32e853d4e24aa00548f787989bbe6e5f98ebfb703855d09
+  languageName: node
+  linkType: hard
+
+"help-me@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "help-me@npm:5.0.0"
+  checksum: 10c0/054c0e2e9ae2231c85ab5e04f75109b9d068ffcc54e58fb22079822a5ace8ff3d02c66fd45379c902ad5ab825e5d2e1451fcc2f7eab1eb49e7d488133ba4cacb
   languageName: node
   linkType: hard
 
@@ -8172,6 +8208,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimist@npm:^1.2.6":
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+  checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
+  languageName: node
+  linkType: hard
+
 "minipass-collect@npm:^2.0.1":
   version: 2.0.1
   resolution: "minipass-collect@npm:2.0.1"
@@ -8850,6 +8893,29 @@ __metadata:
   dependencies:
     split2: "npm:^4.0.0"
   checksum: 10c0/02c05b8f2ffce0d7c774c8e588f61e8b77de8ccb5f8125afd4a7325c9ea0e6af7fb78168999657712ae843e4462bb70ac550dfd6284f930ee57f17f486f25a9f
+  languageName: node
+  linkType: hard
+
+"pino-pretty@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "pino-pretty@npm:13.0.0"
+  dependencies:
+    colorette: "npm:^2.0.7"
+    dateformat: "npm:^4.6.3"
+    fast-copy: "npm:^3.0.2"
+    fast-safe-stringify: "npm:^2.1.1"
+    help-me: "npm:^5.0.0"
+    joycon: "npm:^3.1.1"
+    minimist: "npm:^1.2.6"
+    on-exit-leak-free: "npm:^2.1.0"
+    pino-abstract-transport: "npm:^2.0.0"
+    pump: "npm:^3.0.0"
+    secure-json-parse: "npm:^2.4.0"
+    sonic-boom: "npm:^4.0.1"
+    strip-json-comments: "npm:^3.1.1"
+  bin:
+    pino-pretty: bin.js
+  checksum: 10c0/015dac25006c1b9820b9e01fccb8a392a019e12b30e6bfc3f3f61ecca8dbabcd000a8f3f64410b620b7f5d08579ba85e6ef137f7fbeaad70d46397a97a5f75ea
   languageName: node
   linkType: hard
 
@@ -9697,6 +9763,13 @@ __metadata:
     refa: "npm:^0.12.0"
     regexp-ast-analysis: "npm:^0.7.0"
   checksum: 10c0/47eb72cf913693b453b7622dfee26871b4c408169874b31b8a1f3de8f41698e6dbacd7565fccc8d24cd2fd30f53c21f16995a7f9072e8b25cd938a6c3a750c3c
+  languageName: node
+  linkType: hard
+
+"secure-json-parse@npm:^2.4.0":
+  version: 2.7.0
+  resolution: "secure-json-parse@npm:2.7.0"
+  checksum: 10c0/f57eb6a44a38a3eeaf3548228585d769d788f59007454214fab9ed7f01fbf2e0f1929111da6db28cf0bcc1a2e89db5219a59e83eeaec3a54e413a0197ce879e4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,11 +82,13 @@ __metadata:
     "@types/node": "npm:^22.10.6"
     "@typescript-eslint/parser": "npm:^8.20.0"
     "@vitest/coverage-v8": "npm:2.1.8"
+    dotenv: "npm:^16.4.7"
+    drizzle-orm: "npm:^0.39.1"
     eslint: "npm:^9.18.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-import-resolver-typescript: "npm:^3.7.0"
     license-checker-rseidelsohn: "npm:^4.4.2"
-    pino-pretty: "npm:^13.0.0"
+    postgres: "npm:^3.4.5"
     prettier: "npm:^3.4.2"
     tsup: "npm:^8.3.5"
     tsx: "npm:^4.19.2"
@@ -5285,13 +5287,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colorette@npm:^2.0.7":
-  version: 2.0.20
-  resolution: "colorette@npm:2.0.20"
-  checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
-  languageName: node
-  linkType: hard
-
 "combined-stream@npm:^1.0.8":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
@@ -5430,13 +5425,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dateformat@npm:^4.6.3":
-  version: 4.6.3
-  resolution: "dateformat@npm:4.6.3"
-  checksum: 10c0/e2023b905e8cfe2eb8444fb558562b524807a51cdfe712570f360f873271600b5c94aebffaf11efb285e2c072264a7cf243eadb68f3eba0f8cc85fb86cd25df6
-  languageName: node
-  linkType: hard
-
 "debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.6, debug@npm:^4.3.7":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
@@ -5542,6 +5530,108 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10c0/c96bdccabe9d62ab6fea9399fdff04a66e6563c1d6fb3a3a063e8d53c3bb136ba63e84250bbf63d00086a769ad53aef92d2bd483f03f837fc97b71cbee6b2520
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.4.7":
+  version: 16.4.7
+  resolution: "dotenv@npm:16.4.7"
+  checksum: 10c0/be9f597e36a8daf834452daa1f4cc30e5375a5968f98f46d89b16b983c567398a330580c88395069a77473943c06b877d1ca25b4afafcdd6d4adb549e8293462
+  languageName: node
+  linkType: hard
+
+"drizzle-orm@npm:^0.39.1":
+  version: 0.39.1
+  resolution: "drizzle-orm@npm:0.39.1"
+  peerDependencies:
+    "@aws-sdk/client-rds-data": ">=3"
+    "@cloudflare/workers-types": ">=4"
+    "@electric-sql/pglite": ">=0.2.0"
+    "@libsql/client": ">=0.10.0"
+    "@libsql/client-wasm": ">=0.10.0"
+    "@neondatabase/serverless": ">=0.10.0"
+    "@op-engineering/op-sqlite": ">=2"
+    "@opentelemetry/api": ^1.4.1
+    "@planetscale/database": ">=1"
+    "@prisma/client": "*"
+    "@tidbcloud/serverless": "*"
+    "@types/better-sqlite3": "*"
+    "@types/pg": "*"
+    "@types/react": ">=18"
+    "@types/sql.js": "*"
+    "@vercel/postgres": ">=0.8.0"
+    "@xata.io/client": "*"
+    better-sqlite3: ">=7"
+    bun-types: "*"
+    expo-sqlite: ">=14.0.0"
+    knex: "*"
+    kysely: "*"
+    mysql2: ">=2"
+    pg: ">=8"
+    postgres: ">=3"
+    react: ">=18"
+    sql.js: ">=1"
+    sqlite3: ">=5"
+  peerDependenciesMeta:
+    "@aws-sdk/client-rds-data":
+      optional: true
+    "@cloudflare/workers-types":
+      optional: true
+    "@electric-sql/pglite":
+      optional: true
+    "@libsql/client":
+      optional: true
+    "@libsql/client-wasm":
+      optional: true
+    "@neondatabase/serverless":
+      optional: true
+    "@op-engineering/op-sqlite":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@planetscale/database":
+      optional: true
+    "@prisma/client":
+      optional: true
+    "@tidbcloud/serverless":
+      optional: true
+    "@types/better-sqlite3":
+      optional: true
+    "@types/pg":
+      optional: true
+    "@types/react":
+      optional: true
+    "@types/sql.js":
+      optional: true
+    "@vercel/postgres":
+      optional: true
+    "@xata.io/client":
+      optional: true
+    better-sqlite3:
+      optional: true
+    bun-types:
+      optional: true
+    expo-sqlite:
+      optional: true
+    knex:
+      optional: true
+    kysely:
+      optional: true
+    mysql2:
+      optional: true
+    pg:
+      optional: true
+    postgres:
+      optional: true
+    prisma:
+      optional: true
+    react:
+      optional: true
+    sql.js:
+      optional: true
+    sqlite3:
+      optional: true
+  checksum: 10c0/0707c1acb46c72c4217d8bcecc00057e8a0267e155743a05d31274cd80989c6811edbb20c75b5ce1bdeaa691cdb41f5aaad9705b278fe94a7784a820cdb9f87b
   languageName: node
   linkType: hard
 
@@ -6498,13 +6588,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-copy@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "fast-copy@npm:3.0.2"
-  checksum: 10c0/02e8b9fd03c8c024d2987760ce126456a0e17470850b51e11a1c3254eed6832e4733ded2d93316c82bc0b36aeb991ad1ff48d1ba95effe7add7c3ab8d8eb554a
-  languageName: node
-  linkType: hard
-
 "fast-decode-uri-component@npm:^1.0.1":
   version: 1.0.1
   resolution: "fast-decode-uri-component@npm:1.0.1"
@@ -6587,13 +6670,6 @@ __metadata:
   version: 3.5.0
   resolution: "fast-redact@npm:3.5.0"
   checksum: 10c0/7e2ce4aad6e7535e0775bf12bd3e4f2e53d8051d8b630e0fa9e67f68cb0b0e6070d2f7a94b1d0522ef07e32f7c7cda5755e2b677a6538f1e9070ca053c42343a
-  languageName: node
-  linkType: hard
-
-"fast-safe-stringify@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "fast-safe-stringify@npm:2.1.1"
-  checksum: 10c0/d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
   languageName: node
   linkType: hard
 
@@ -7101,13 +7177,6 @@ __metadata:
   version: 8.0.0
   resolution: "helmet@npm:8.0.0"
   checksum: 10c0/c3d273df206cbb4e5e830ea68afdbd3d0f8e055b2707f67f651ebb4b679c7fd4d6ac77ce6188a2cee32e853d4e24aa00548f787989bbe6e5f98ebfb703855d09
-  languageName: node
-  linkType: hard
-
-"help-me@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "help-me@npm:5.0.0"
-  checksum: 10c0/054c0e2e9ae2231c85ab5e04f75109b9d068ffcc54e58fb22079822a5ace8ff3d02c66fd45379c902ad5ab825e5d2e1451fcc2f7eab1eb49e7d488133ba4cacb
   languageName: node
   linkType: hard
 
@@ -8103,13 +8172,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.6":
-  version: 1.2.8
-  resolution: "minimist@npm:1.2.8"
-  checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
-  languageName: node
-  linkType: hard
-
 "minipass-collect@npm:^2.0.1":
   version: 2.0.1
   resolution: "minipass-collect@npm:2.0.1"
@@ -8791,29 +8853,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pino-pretty@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "pino-pretty@npm:13.0.0"
-  dependencies:
-    colorette: "npm:^2.0.7"
-    dateformat: "npm:^4.6.3"
-    fast-copy: "npm:^3.0.2"
-    fast-safe-stringify: "npm:^2.1.1"
-    help-me: "npm:^5.0.0"
-    joycon: "npm:^3.1.1"
-    minimist: "npm:^1.2.6"
-    on-exit-leak-free: "npm:^2.1.0"
-    pino-abstract-transport: "npm:^2.0.0"
-    pump: "npm:^3.0.0"
-    secure-json-parse: "npm:^2.4.0"
-    sonic-boom: "npm:^4.0.1"
-    strip-json-comments: "npm:^3.1.1"
-  bin:
-    pino-pretty: bin.js
-  checksum: 10c0/015dac25006c1b9820b9e01fccb8a392a019e12b30e6bfc3f3f61ecca8dbabcd000a8f3f64410b620b7f5d08579ba85e6ef137f7fbeaad70d46397a97a5f75ea
-  languageName: node
-  linkType: hard
-
 "pino-std-serializers@npm:^7.0.0":
   version: 7.0.0
   resolution: "pino-std-serializers@npm:7.0.0"
@@ -8978,6 +9017,13 @@ __metadata:
   version: 1.1.4
   resolution: "postgres-range@npm:1.1.4"
   checksum: 10c0/254494ef81df208e0adeae6b66ce394aba37914ea14c7ece55a45fb6691b7db04bee74c825380a47c887a9f87158fd3d86f758f9cc60b76d3a38ce5aca7912e8
+  languageName: node
+  linkType: hard
+
+"postgres@npm:^3.4.5":
+  version: 3.4.5
+  resolution: "postgres@npm:3.4.5"
+  checksum: 10c0/53415acea77e97bdc1eeb861048f34964e2236e4d4d42f408fc9b901e62bfcf7443a487ebfdad18b57b468c6e297bf8d22097106a200f62eb1262eb5a71355df
   languageName: node
   linkType: hard
 
@@ -9651,13 +9697,6 @@ __metadata:
     refa: "npm:^0.12.0"
     regexp-ast-analysis: "npm:^0.7.0"
   checksum: 10c0/47eb72cf913693b453b7622dfee26871b4c408169874b31b8a1f3de8f41698e6dbacd7565fccc8d24cd2fd30f53c21f16995a7f9072e8b25cd938a6c3a750c3c
-  languageName: node
-  linkType: hard
-
-"secure-json-parse@npm:^2.4.0":
-  version: 2.7.0
-  resolution: "secure-json-parse@npm:2.7.0"
-  checksum: 10c0/f57eb6a44a38a3eeaf3548228585d769d788f59007454214fab9ed7f01fbf2e0f1929111da6db28cf0bcc1a2e89db5219a59e83eeaec3a54e413a0197ce879e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Hi, I've done:

1. Integrated Supabase as a storage solution for the queue system
2. Added SUPABASE_URL as a secret environment variable to control whether the system uses Supabase or falls back to file-based storage
3. Used Drizzle ORM for database interactions

Issue:
- Encountered a getaddrinfo ENOTFOUND error when trying to connect to Supabase using Direct Connection.

I checked Supabase's "Connect to Project" documentation and found that Drizzle ORM’s example .env also uses the Transaction Pooler instead of Direct Connection. So I switched to Transaction Pooler for database connections.

Let me know if there are any concerns or if Direct Connection should be used differently. Thanks.

This PR will fix #123 

